### PR TITLE
Add php postgres package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     apt-get install -y \
     nginx-light \
     php7.3-mysql \
+    php7.3-pgsql \
     php7.3-imagick \
     php7.3-mbstring \
     php7.3-json \


### PR DESCRIPTION
I tried to use Lychee with a postgres database and various errors in laravel/log showed that the package wasn't installed... so I added it to the dockerfile.

Tested working fine for a few minutes. 