### PR TITLE
deploy is now on it's on step, should not break on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ before_script:
 script:
   - docker ps -a | awk '{print $NF}' | grep -w $NAME | cat
 
-after_success:
-  - ./deploy.sh
+deploy:
+  - provider: script
+    script: ./deploy.sh
 
 after_script:
   - docker stop $NAME && docker rm $NAME


### PR DESCRIPTION
I noticed that most PR breaks because of the deploy step.

By moving this step to the `deploy` section instead of `after_success` we are supposed to have the same behaviour and also allows to not crash the build for other PR.