### PR TITLE
Override PHP configuration via PHP-FPM, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,45 @@
 [![Release](https://img.shields.io/github/release/LycheeOrg/Lychee-Laravel-Docker.svg?style=flat)](https://github.com/LycheeOrg/Lychee-Laravel-Docker/releases)
 ![Last Commit](https://img.shields.io/github/last-commit/LycheeOrg/Lychee-Laravel-Docker.svg?style=flat)
 
-## Prerequisites ##
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-*  You must have a database docker running **OR** create one in your docker-compose.yml.
+	- [Image content](#image-content)
+	- [Setup](#setup)
+		- [Prerequisites](#prerequisites)
+		- [Run with Docker](#run-with-docker)
+		- [Run with Docker Compose](#run-with-docker-compose)
+	- [Available environment variables and defaults](#available-environment-variables-and-defaults)
+	- [Advanced configuration](#advanced-configuration)
+
+<!-- /TOC -->
 
 ## Image content
 
-This image features Lychee (Laravel version), nginx and PHP-FPM.
+This image features Lychee (Laravel version), nginx and PHP-FPM. The provided configuration (PHP, nginx...) follows Lychee's official recommandations.
 
-Note that nginx will accept by default images up to 100MB (`client_max_body_size 100M`), according to the [recommendations of the Lychee-Laravel FAQ](https://github.com/LycheeOrg/Lychee/wiki/FAQ#i-cant-upload-photos). However, to upload large files, you will need to modify `php.ini` directives as well (see FAQ). To do so, please mount your custom `php.ini` file to `/etc/php/7.3/php/php.ini`.
+The following tags are available :
 
-## Setup ##
+* `latest`: current stable tag
+* `v[NUMBER]`: stable version tag
+* `dev`: current master branch tag
+* `testing`: branch and pr tag for testing
+
+## Setup
+
+### Prerequisites
+
+You must have a database docker running **OR** create one in your `docker-compose.yml`.
 
 1.  Create the db, username, password.
-2.  Edit the environment variables:
-    *  Supply the environment variables via `docker run` / `docker-compose`, **or**
-    *  Create a `.env` file with the appropriate info and mount it to `/conf`.
+2.  Edit the environment variables (db credentials, language...) by :
+    *  Supplying the environment variables via `docker run` / `docker-compose`, **or**
+    *  Creating a `.env` file with the appropriate info and mount it to `/conf/.env`.
 
-## Available Docker Tags ##
-* **latest**: current stable tag
-* **v[NUMBER]**: stable version tag
-* **dev**: current master branch tag
-* **testing**: branch and pr tag for testing
+### Run with Docker
 
-## Example docker run command ##
+**Make sure that you link to the container running your database !!**  
 
-1.  **Make sure that you link to the container running your database!!**  
-    The example below shows --net and --link for these purposes  
-    --net connects to the name of the network your database is on  
-    --link connects to the database  
+The example below shows `--net` and `--link` for these purposes. `--net` connects to the name of the network your database is on and  `--link` connects to the database container.
 
 ```bash
 docker run -d \
@@ -59,18 +69,33 @@ bigrob8181/lychee-laravel
 alter user 'lychee' identified with mysql_native_password by '<your password>';
 ```
 
-## Example docker-compose.yml ##
+### Run with Docker Compose
 
-Change the environment variable in the [provided example](docker-compose.yml) to reflect your database credentials.
+Change the environment variables in the [provided example](./docker-compose.yml) to reflect your database credentials.
 
 Note that in order to avoid writing credentials directly into the file, you can create a `db_secrets.env` and use the `env_file` directive (see the [docs](https://docs.docker.com/compose/environment-variables/#the-env_file-configuration-option)).
 
-## Available Environment Variables and defaults ##
+## Available environment variables and defaults
 
-If you do not provide environment variables or `.conf` file, the [example env file](https://github.com/LycheeOrg/Lychee-Laravel/blob/master/.env.example) will be used with some values already set by default.
+If you do not provide environment variables or `.env` file, the [example .env file](https://github.com/LycheeOrg/Lychee-Laravel/blob/master/.env.example) will be used with some values already set by default.
 
 Some variables are specific to Docker, and the default values are :
+
 * PUID=1000  
 * PGID=1000  
 * USER=lychee
 * PHP_TZ=America/New_York
+
+## Advanced configuration
+
+Note that nginx will accept by default images up to 100MB (`client_max_body_size 100M`) and that PHP parameters are overridden according to the [recommendations of the Lychee-Laravel FAQ](https://github.com/LycheeOrg/Lychee/wiki/FAQ#i-cant-upload-photos).
+
+You may still want to further customize PHP configuration. The first method is to mount a custom `php.ini` to `/etc/php/7.3/fpm/php.ini` when starting the container. However, this method is kind of brutal as it will override all parameters.
+
+Instead, we recommend to use the `PHP_VALUE` directive of PHP-FPM to override specific parameters. To do so, you will need to mount a custom `nginx.conf` in your container :
+
+1. Take the [default.conf](./default.conf) file as a base
+2. Find the line starting by `fastcgi_param PHP_VALUE [...]`
+3. Add a new line and set your new parameter
+4. Mount your new file to `/etc/nginx/nginx.conf`
+

--- a/default.conf
+++ b/default.conf
@@ -72,6 +72,11 @@ http {
 	        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
 	        fastcgi_index index.php;
 	        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param PHP_VALUE "post_max_size=100M
+					max_execution_time=200
+					upload_max_size=100M
+					upload_max_filesize=20M
+					memory_limit=256M";
 	        include fastcgi_params;
 	    }
 	}


### PR DESCRIPTION
Directly set recommended values for Lychee via PHP_VALUE directive in nginx.conf.

Also update the README to help people to further change nginx and/or PHP configuration, and reorganize a bit.

This should "fix" #19 and improve initial configuration.

Can you look @roblandry ? :)