### PR TITLE
fix(nginx): remove invalid PHP value

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -74,7 +74,6 @@ http {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PHP_VALUE "post_max_size=100M
                 max_execution_time=200
-                upload_max_size=100M
                 upload_max_filesize=20M
                 memory_limit=256M";
             fastcgi_param PATH /usr/local/bin:/usr/bin:/bin;


### PR DESCRIPTION
Resolves https://github.com/LycheeOrg/Lychee-Laravel-Docker/issues/33

The value `upload_max_size` does not exist in the PHP ini.

2nd source: https://stackoverflow.com/questions/45712556/difference-between-upload-max-size-and-upload-max-filesize