### PR TITLE
Use Lychee's version on Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,7 @@ jobs:
       script:
         - echo "$REGISTRY_PASS" | docker login -u $REGISTRY_USER --password-stdin
         - echo "Building multi arch and pushing testing"
-        - docker buildx build
-            --progress plain
-            --platform linux/arm/v7,linux/arm/v6,linux/arm64,linux/amd64
-            -t $DOCKER_REPO':testing'
-            --push
-            .
+        - ./deploy.sh
 
     # Pull images and test them
     - stage: "Test amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ENV PGID='1000'
 ENV USER='lychee'
 ENV PHP_TZ=America/New_York
 
+# Arguments
+# To use the latest Lychee release instead of master pass `--build-arg TARGET=release` to `docker build`
+ARG TARGET
+
 # Add User and Group
 RUN \
     addgroup --gid "$PGID" "$USER" && \
@@ -34,9 +38,12 @@ RUN \
     git \
     composer && \
     cd /var/www/html && \
-    git clone --depth 1 https://github.com/LycheeOrg/Lychee.git && \
-    apt-get install -y composer && \
+    if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; fi && \
+    git clone --depth 1 $RELEASE_TAG https://github.com/LycheeOrg/Lychee.git && \
     cd /var/www/html/Lychee && \
+    echo "Last release: $(cat version.md)" && \
+    git fetch --depth=1 origin tag v$(cat version.md) && \
+    apt-get install -y composer && \
     composer install --no-dev && \
     chown -R www-data:www-data /var/www/html/Lychee && \
     apt-get purge -y git composer && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PHP_TZ=America/New_York
 
 # Arguments
 # To use the latest Lychee release instead of master pass `--build-arg TARGET=release` to `docker build`
-ARG TARGET
+ARG TARGET=dev
 
 # Add User and Group
 RUN \
@@ -21,7 +21,7 @@ RUN \
 # Install base dependencies, clone the repo and install php libraries
 RUN \
     apt-get update && \
-    apt-get install -y \
+    apt-get install -qy \
     nginx-light \
     php7.3-mysql \
     php7.3-pgsql \
@@ -40,14 +40,12 @@ RUN \
     cd /var/www/html && \
     if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; fi && \
     git clone --depth 1 $RELEASE_TAG https://github.com/LycheeOrg/Lychee.git && \
+    echo "$TARGET" > /var/www/html/Lychee/docker_target && \
     cd /var/www/html/Lychee && \
     echo "Last release: $(cat version.md)" && \
-    git fetch --depth=1 origin tag v$(cat version.md) && \
-    apt-get install -y composer && \
     composer install --no-dev && \
     chown -R www-data:www-data /var/www/html/Lychee && \
-    apt-get purge -y git composer && \
-    apt-get autoremove -y && \
+    apt-get purge -y --autoremove git composer && \
     rm -rf /var/lib/apt/lists/*
 
 # Add custom site to apache

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@ echo '
  |_____\__,_|_|  \__,_| \_/ \___|_|
 
 -------------------------------------
-Lychee Commit:  '$shorthash'
 Lychee Version: '$lycheeversion' ('$target')
+Lychee Commit:  '$shorthash'
 https://github.com/LycheeOrg/Lychee/commit/'$longhash'
 -------------------------------------'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,16 +7,7 @@ set -e
 read -r longhash < /var/www/html/Lychee/.git/refs/heads/master
 shorthash=$(echo $longhash |cut -c1-7)
 lycheeversion=$(</var/www/html/Lychee/version.md)
-read -r -a taghash < /var/www/html/Lychee/.git/FETCH_HEAD
-
-# Are we using a release or master?
-if [ "$longhash" = "${taghash[0]}" ]
-then
-	releaseinfo="Lychee release: $lycheeversion"
-else
-	releaseinfo="Previous release: $lycheeversion"
-	shorthash="$shorthash (dev)"
-fi
+target=$(</var/www/html/Lychee/docker_target)
 
 echo '
 -------------------------------------
@@ -31,8 +22,8 @@ echo '
  |_____\__,_|_|  \__,_| \_/ \___|_|
 
 -------------------------------------
-Lychee Commit: '$shorthash'
-'$releaseinfo'
+Lychee Commit:  '$shorthash'
+Lychee Version: '$lycheeversion' ('$target')
 https://github.com/LycheeOrg/Lychee/commit/'$longhash'
 -------------------------------------'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -6,6 +6,17 @@ set -e
 # This prevents installing git, and allows display of commit
 read -r longhash < /var/www/html/Lychee/.git/refs/heads/master
 shorthash=$(echo $longhash |cut -c1-7)
+lycheeversion=$(</var/www/html/Lychee/version.md)
+read -r -a taghash < /var/www/html/Lychee/.git/FETCH_HEAD
+
+# Are we using a release or master?
+if [ "$longhash" = "${taghash[0]}" ]
+then
+	releaseinfo="Lychee release: $lycheeversion"
+else
+	releaseinfo="Previous release: $lycheeversion"
+	shorthash="$shorthash (dev)"
+fi
 
 echo '
 -------------------------------------
@@ -20,7 +31,8 @@ echo '
  |_____\__,_|_|  \__,_| \_/ \___|_|
 
 -------------------------------------
-Latest Commit: '$shorthash'
+Lychee Commit: '$shorthash'
+'$releaseinfo'
 https://github.com/LycheeOrg/Lychee/commit/'$longhash'
 -------------------------------------'
 


### PR DESCRIPTION
- Use latest Lychee release in Travis for new tagged builds.
- Show Lychee version (as well as commit) in `entrypoint.sh`

As part of this I refactored `deploy.sh` a little to reduce some duplication.